### PR TITLE
Fixed crash on ioSource Advertise without external id

### DIFF
--- a/Sources/CoatySwift/Classes/Communication/Manager/CommunicationManager.swift
+++ b/Sources/CoatySwift/Classes/Communication/Manager/CommunicationManager.swift
@@ -476,7 +476,7 @@ public class CommunicationManager {
         // Update own IO actor associations
         if isIoActorAssociated {
             if let ioRoute = ioRoute {
-                self.associateIoActorItems(ioSourceId: ioSourceId, ioActor: ioActor!, ioRoute: ioRoute, isExternalRoute: event.data.isExternalRoute!)
+                self.associateIoActorItems(ioSourceId: ioSourceId, ioActor: ioActor!, ioRoute: ioRoute, isExternalRoute: event.data.isExternalRoute ?? false)
             } else {
                 self.disassociateIoActorItems(ioSourceId: ioSourceId, ioActorId: ioActorId, currentIoRoute: nil, newIoRoute: nil)
             }


### PR DESCRIPTION
Communication Manager was crashing when provided with IoSources without externals routes. External routes are optional in the TS implementation.

Note that this PR is for the SPM-Support branch.